### PR TITLE
CL - padding explained

### DIFF
--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Padding/PaddingInterfaces.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Padding/PaddingInterfaces.swift
@@ -1,0 +1,4 @@
+protocol PaddingWireframeInterface: WireframeInterface {
+    func goBack()
+}
+

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Padding/PaddingPresenter.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Padding/PaddingPresenter.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SwiftUI
+
+final class PaddingPresenter: ObservableObject {
+
+    // MARK: - Properties
+
+    private let wireframe: PaddingWireframeInterface
+
+    // MARK: - Lifecycle
+
+    init(wireframe: PaddingWireframeInterface) {
+        self.wireframe = wireframe
+    }
+
+    // MARK: - Navigation
+
+    func goBack() {
+        wireframe.goBack()
+    }
+}

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Padding/PaddingView.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Padding/PaddingView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct PaddingView: View {
+    @ObservedObject var presenter: PaddingPresenter
+    
+    var body: some View {
+           VStack(spacing: 20) {
+               //Go back button
+               Button(action: presenter.goBack) {
+                   Image(systemName: "chevron.left")
+                       .font(.title2)
+                       .padding()
+                       .background(Color.gray.opacity(0.2))
+                       .clipShape(Circle())
+               }
+               .frame(maxWidth: .infinity, alignment: .leading)
+               
+               Spacer()
+               
+               // Text with no padding
+               Text("This text has no padding.")
+                   .border(Color.red, width: 3)
+               
+               // Text with default padding
+               Text("This text has default padding.")
+                   .padding()
+                   .border(Color.blue, width: 3)
+               
+               // Text with specific padding on the leading side
+               Text("This text has padding only on the leading side.")
+                   .padding(.leading, 50)
+                   .border(Color.green, width: 3)
+               
+               // Text with different horizontal and vertical padding
+               Text("This text has larger horizontal padding and smaller vertical padding.")
+                   .padding(.horizontal, 60) // Larger horizontal padding
+                   .padding(.vertical, 20)   // Smaller vertical padding
+                   .border(Color.orange, width: 3)
+               
+               Spacer()
+           }
+           .padding(20) // General padding for the VStack
+           .background(Color.gray.opacity(0.2)) // Background to highlight the VStack area
+       }
+   }

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Padding/PaddingWireframe.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Padding/PaddingWireframe.swift
@@ -1,0 +1,20 @@
+final class PaddingWireframe: BaseWireframe<LazyHostingViewController<PaddingView>> {
+
+    // MARK: - Module setup
+
+    init() {
+        let moduleViewController = LazyHostingViewController<PaddingView>(isNavigationBarHidden: true)
+        super.init(viewController: moduleViewController)
+
+        let presenter = PaddingPresenter(wireframe: self)
+        moduleViewController.rootView = PaddingView(presenter: presenter)
+    }
+}
+
+// MARK: - Extensions
+
+extension PaddingWireframe: PaddingWireframeInterface {
+    func goBack() {
+        navigationController?.popViewController(animated: true)
+    }
+}

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeInterfaces.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeInterfaces.swift
@@ -29,5 +29,6 @@ protocol HomeWireframeInterface: WireframeInterface {
     
     func showLazyVGridView()
     func showEllipse()
+    func showPadding()
 
 }

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomePresenter.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomePresenter.swift
@@ -120,4 +120,9 @@ final class HomePresenter: ObservableObject {
     func showEllipse(){
         wireframe.showEllipse()
     }
+    
+    /// Navigates to Padding
+    func showPadding() {
+        wireframe.showPadding()
+    }
 }

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeView.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeView.swift
@@ -232,7 +232,8 @@ struct HomeView: View {
                             ButtonModel(title: "Go to ContextMenu", action: { presenter.showContextMenu()}),
                             ButtonModel(title: "Go to Stepper", action: { presenter.showStepper() }),
                             ButtonModel(title: "Go to LazyVGrid", action: { presenter.showLazyVGridView() }),
-                            ButtonModel(title: "Go to Ellipse", action: { presenter.showEllipse() })
+                            ButtonModel(title: "Go to Ellipse", action: { presenter.showEllipse() }),
+                            ButtonModel(title: "Go to Padding", action: { presenter.showPadding() }),
 
                         ]
 

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeWireframe.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeWireframe.swift
@@ -130,5 +130,10 @@ extension HomeWireframe: HomeWireframeInterface {
         let ellipseWireframe = EllipseWireframe()
         navigationController?.pushWireframe(ellipseWireframe)
     }
+    
+    func showPadding() {
+        let paddingWireframe = PaddingWireframe()
+        navigationController?.pushWireframe(paddingWireframe)
+    }
 
 }


### PR DESCRIPTION
## 📋 PR Description

<!-- Provide a brief description of the changes introduced by this PR. -->

This PR introduces a PaddingView built using the VIPER architecture. The view demonstrates various padding configurations applied to Text components, showcasing how padding affects layout and spacing. A "Go Back" button is also included for navigation. This feature serves as an educational and practical demonstration of padding in SwiftUI, providing clear examples for different use cases.

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [x] Test coverage is adequate for the changes.
- [ ] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [ ] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

<!-- Provide a clear, step-by-step description of how to test the changes introduced by this PR. -->
1.Launch the app and navigate to the view where the PaddingView is integrated.
2.Verify that the "Go Back" button appears at the top-left corner and functions correctly.
3.Check the following text components:
4.No Padding: Ensure the text is directly bordered with no extra space.
5.Default Padding: Confirm the text has default padding and is bordered with blue.
6.Leading Padding: Verify the text has additional space only on the left and is bordered with green.
7.Custom Horizontal & Vertical Padding: Check that the text has wider horizontal and narrower vertical padding, bordered with orange.
8.Ensure the layout is responsive and visually consistent across various screen sizes.
9.Test that the presenter handles the navigation logic for the "Go Back" button.
---

## 🔗 Related Links

- Documentation: https://www.kodeco.com/books/swiftui-cookbook/v1.0/chapters/8-adding-padding-spacing-in-swiftui

---

### 📷 Screenshots (Optional)
![Simulator Screenshot - iPhone 16 Pro - 2024-12-29 at 13 34 07](https://github.com/user-attachments/assets/46b0a60d-6d56-4dd1-bba3-304718fa7512)
<!-- Attach any relevant screenshots to illustrate the changes, especially for UI updates. -->