### PR TITLE
CL - GoBack Button Added to LinkView Page

### DIFF
--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Link/LinkView.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Link/LinkView.swift
@@ -3,41 +3,57 @@ import SwiftUI
 struct LinkView: View {
     @ObservedObject var presenter: LinkPresenter
     @State private var fetchStatus: String = "Fetching data..." // Başlangıç durumu
-    
+    @State private var color: Color = .blue
     var body: some View {
-        VStack {
-            Spacer()
-            
-            // Title
-            Text("Link Page")
-                .font(.largeTitle)
-                .padding(.bottom, 16)
-            
-            // Data status
-            Text(fetchStatus)
-                .foregroundColor(fetchStatus.contains("successfully") ? .green : .gray)
-                .padding(.bottom, 16)
-            
-            // Data pull button
-            Button(action: {
-                fetchStatus = "Fetching data..."
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { // Simulated delay
-                    fetchStatus = "Link data successfully fetched!"
+        ZStack(alignment: .topLeading) { // Align content to the top-left corner
+            VStack {
+                Spacer()
+                
+                // Title
+                Text("Link Page")
+                    .font(.largeTitle)
+                    .padding(.bottom, 16)
+                
+                // Data status
+                Text(fetchStatus)
+                    .foregroundColor(fetchStatus.contains("successfully") ? .green : .gray)
+                    .padding(.bottom, 16)
+                
+                // Data pull button
+                Button(action: {
+                    fetchStatus = "Fetching data..."
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) { // Simulated delay
+                        fetchStatus = "Link data successfully fetched!"
+                    }
+                }) {
+                    Text("Fetch Link Data")
+                        .foregroundColor(.white)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color.blue)
+                        .cornerRadius(8)
                 }
-            }) {
-                Text("Fetch Link Data")
-                    .foregroundColor(.white)
-                    .padding()
-                    .frame(maxWidth: .infinity)
-                    .background(Color.blue)
-                    .cornerRadius(8)
+                .padding(.horizontal, 24)
+                
+                Spacer()
             }
-            .padding(.horizontal, 24)
+            .padding()
             
-            Spacer()
+            // Back Button in the top-left corner
+            VStack {
+                HStack {
+                    Button(action: presenter.goBack) {
+                        Image(systemName: "chevron.left")
+                            .font(.title2)
+                            .padding()
+                            .background(Color.gray.opacity(0.2))
+                            .clipShape(Circle())
+                    }
+                    Spacer()
+                }
+                Spacer()
+            }
+            .padding()
         }
-        .padding()
-        .navigationTitle("")
-        .navigationBarBackButtonHidden(false)
     }
 }


### PR DESCRIPTION
## 📋 PR Description

This PR fixes an oversight in the `LinkView` by adding a functional back button to ensure proper navigation. The back button has been implemented with SwiftUI and adheres to the project's UI/UX standards.

---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [x] Relevant unit tests are written and all tests are passing.
- [ ] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [ ] Documentation is updated where necessary.
- [x] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1. Navigate to the home screen and click "Go to Link Page."
2. Verify the `LinkView` loads successfully.
3. Confirm the back button is visible in the top-left corner.
4. Click the back button and ensure navigation returns to the home screen.

---

## 🔗 Related Links

- Documentation: https://developer.apple.com/documentation/swiftui/link
---

### 📷 Screenshots (Optional)

<table>
  <thead>
    <tr>
      <th style="padding-left: 20px;">LinkView with Back Button </th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td style="padding-right: 20px;">
        <img src="https://github.com/user-attachments/assets/f5e01dc6-c65e-4bde-a914-11056c7e7719" alt="home page link" width="400"/>
    </tr>
  </tbody>

</table>  

