### PR TITLE
CL - Popover Implementation VIPER

### DIFF
--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Popover/PopoverInterfaces.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Popover/PopoverInterfaces.swift
@@ -1,0 +1,3 @@
+protocol PopoverWireframeInterface: WireframeInterface {
+    func goBack()
+}

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Popover/PopoverPresenter.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Popover/PopoverPresenter.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SwiftUI
+
+final class PopoverPresenter: ObservableObject {
+    
+    // MARK: - Properties
+    
+    private let wireframe: PopoverWireframeInterface
+
+    // MARK: - Lifecycle
+
+    init(wireframe: PopoverWireframeInterface) {
+        self.wireframe = wireframe
+    }
+
+    // MARK: - Navigation
+
+    func goBack() {
+        wireframe.goBack()
+    }
+}

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Popover/PopoverView.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Popover/PopoverView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct PopoverView: View {
+    @ObservedObject var presenter: PopoverPresenter
+    @State private var showPopover = false
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            // Back button with consistent style
+            Button(action: presenter.goBack) {
+                Image(systemName: "chevron.left")
+                    .font(.title2)
+                    .padding(10)
+                    .background(Color.gray.opacity(0.2))
+                    .clipShape(Circle())
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            
+            Spacer()
+            
+            Text("Popover Demo")
+                .font(.title)
+                .padding()
+            
+            Button("Show Popover") {
+                showPopover = true
+            }
+            .padding()
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(10)
+            .popover(isPresented: $showPopover) {
+                VStack(spacing: 15) {
+                    Text("Popover Content")
+                        .font(.headline)
+                        .padding()
+                    
+                    Text("This is a popover example")
+                        .font(.body)
+                        .padding()
+                    
+                    Button("Dismiss") {
+                        showPopover = false
+                    }
+                    .padding()
+                    .background(Color.red)
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+                }
+                .padding()
+            }
+            
+            Spacer()
+        }
+        .padding()
+    }
+}

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Popover/PopoverWireframe.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/Components/Popover/PopoverWireframe.swift
@@ -1,0 +1,22 @@
+final class PopoverWireframe:BaseWireframe<LazyHostingViewController<PopoverView>> {
+    
+    // MARK: - Module setup -
+
+    init() {
+        let moduleViewController = LazyHostingViewController<PopoverView>(isNavigationBarHidden: true)
+        super.init(viewController: moduleViewController)
+
+        let presenter = PopoverPresenter(wireframe: self)
+        moduleViewController.rootView = PopoverView(presenter: presenter)
+        }
+}
+
+// MARK: - Extensions -
+
+extension PopoverWireframe:PopoverWireframeInterface{
+    
+    func goBack() {
+        navigationController?.popViewController(animated: true)
+    }
+}
+

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeInterfaces.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeInterfaces.swift
@@ -124,6 +124,6 @@ protocol HomeWireframeInterface: WireframeInterface {
     func showCustomShape()
     
     func showGeometryReader()
-
+    func showPopover()
 
 }

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomePresenter.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomePresenter.swift
@@ -402,4 +402,7 @@ final class HomePresenter: ObservableObject {
             wireframe.showGeometryReader()
         }
 
+    func showPopover() {
+        wireframe.showPopover()
+    }
 }

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeView.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeView.swift
@@ -380,7 +380,8 @@ struct HomeView: View {
                             ButtonModel(title: "Go to CustomShape", action: { presenter.showCustomShape()}),
                             ButtonModel(title: "Go to ForegroundColor", action: {presenter.showForegroundColor()}),
                             
-                            ButtonModel(title: "Go to Geometry Reader", action: {presenter.showGeometryReader()})
+                            ButtonModel(title: "Go to Geometry Reader", action: {presenter.showGeometryReader()}),
+                            ButtonModel(title:"Go to Popover", action: {presenter.showPopover()}),
 
 
                         ]

--- a/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeWireframe.swift
+++ b/SwiftUI/SwiftUI-Components-App/DemoApp/Modules/Home/HomeWireframe.swift
@@ -382,4 +382,8 @@ extension HomeWireframe: HomeWireframeInterface {
         navigationController?.pushWireframe(geometryReaderWireframe)
     }
     
+    func showPopover() {
+        let popoverWireframe = PopoverWireframe()
+        navigationController?.pushWireframe(popoverWireframe)
+    }
 }


### PR DESCRIPTION
## 📋 PR Description

This PR introduces a PopoverView that demonstrates how to present and dismiss a popover in SwiftUI. Users can trigger the popover by tapping a button, which displays a simple modal with content and a dismiss button. Navigation and lifecycle management are handled by PopoverPresenter and PopoverWireframe, ensuring clean and modular architecture. The implementation follows SwiftUI best practices, providing a smooth user experience with intuitive popover interactions and consistent back navigation.

---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [ ] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [ ] Documentation is updated where necessary.
- [ ] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1.Run the Application:
     •Launch the app and navigate to the screen containing the PopoverView.
2.Popover Presentation:
     •Tap the “Show Popover” button. A popover should appear with the designated content.
3.Dismiss Popover:
     •Press the “Dismiss” button inside the popover. The popover should close immediately.
4.Back Navigation:
     •Tap the back button (top left corner). The view should navigate to the previous screen without issues.
5.Edge Case Testing:
     •Repeatedly show and dismiss the popover to ensure no performance or rendering issues occur.
     •Test interaction by dismissing the popover by tapping outside of it (iPad or large screen behavior).
6.UI Consistency:
     •Verify the layout, colors, and button responsiveness to ensure the interface aligns with the overall app design.

---

## 🔗 Related Links

- Documentation: https://developer.apple.com/documentation/swiftui/view/popover(ispresented:attachmentanchor:arrowedge:content:)

---

### 📷 Screenshots (Optional)

<img width="281" alt="Screenshot 2025-01-03 at 21 28 08" src="https://github.com/user-attachments/assets/9ce7566c-c2a8-4d2f-bd5a-03aeac9c2d44" />
<img width="281" alt="Screenshot 2025-01-03 at 21 28 12" src="https://github.com/user-attachments/assets/66778622-eeb6-46c4-aec0-eaadc5dae13e" />
<img width="281" alt="Screenshot 2025-01-03 at 21 28 16" src="https://github.com/user-attachments/assets/62c0ee4f-f302-48d5-80be-ca068dfbb27c" />
