### PR TITLE
CL - Fix Duplicate TextFieldType Enum Declaration

### DIFF
--- a/SwiftUI/Swift-Camp-Devs/SwiftCampDevs/Components/TextField/TextFieldComponent.swift
+++ b/SwiftUI/Swift-Camp-Devs/SwiftCampDevs/Components/TextField/TextFieldComponent.swift
@@ -1,12 +1,4 @@
 import SwiftUI
-enum TextFieldType {
-    case username
-    case password
-    case email
-    case search
-    case numeric
-    case custom(placeholder: String, keyboardType: UIKeyboardType)
-}
 
 struct SCTextField: View {
     @Binding var text: String
@@ -65,7 +57,6 @@ struct SCTextField: View {
         case .password: return "Enter your password"
         case .email: return "Enter your email"
         case .search: return "Search"
-        case .numeric: return "Enter a number"
         case .custom(let placeholder, _): return placeholder
         }
     }
@@ -74,7 +65,6 @@ struct SCTextField: View {
         switch type {
         case .username, .password, .email: return .default
         case .search: return .default
-        case .numeric: return .numberPad
         case .custom(_, let keyboardType): return keyboardType
         }
     }
@@ -86,7 +76,6 @@ struct SCTextField: View {
         SCTextField(text: .constant(""), type: .password, borderColor: .red, showPasswordToggle: true, isEnabled: false)
         SCTextField(text: .constant(""), type: .email, borderColor: .green)
         SCTextField(text: .constant(""), type: .search, borderColor: .gray, isEnabled: false)
-        SCTextField(text: .constant(""), type: .numeric, borderColor: .purple)
         SCTextField(text: .constant(""), type: .custom(placeholder: "Enter custom input", keyboardType: .asciiCapable), borderColor: .orange)
     }
     .padding()


### PR DESCRIPTION
## 📋 PR Description

<!-- Provide a brief description of the changes introduced by this PR. -->
The same enum was defined twice in the project, causing the 'Invalid redeclaration of 'TextFieldType'' error. The duplicate definition was removed to fix the issue, and it was verified that the remaining definition is used correctly.

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [x] Test coverage is adequate for the changes.
- [x] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [ ] The PR has been reviewed by at least one team member before merging.

## 🔗 Related Links

- Issue: Duplicate TextFieldType enum causing redeclaration error

### 📷 Screenshots (Optional)
![Screenshot 2025-01-13 at 12 12 08](https://github.com/user-attachments/assets/82127563-31fc-4a19-8ac6-4027ae16e541)