### PR TITLE
# CL - Implemented SettingsHelper for Navigating to Specific Settings Pages via App-Prefs  

### DIFF
--- a/SwiftUI/Swift-Camp-Devs/SwiftCampDevs/Helpers/SettingsHelper.swift
+++ b/SwiftUI/Swift-Camp-Devs/SwiftCampDevs/Helpers/SettingsHelper.swift
@@ -1,0 +1,67 @@
+import UIKit
+
+/// A helper class that provides functionality to open various iOS system settings pages
+class SettingsHelper {
+    static let shared = SettingsHelper()
+    
+    private init() {}
+    
+    enum SettingsType {
+        case appSettings
+        case notificationSettings
+        case microfonSettings
+        case cameraSettings
+        case locationSettings
+        case photosSettings
+        case siriSettings
+        case wifiSettings
+        case bluetoothSettings
+        case cellularSettings
+        case batterySettings
+        case privacySettings
+        
+        /// Returns the URL string for the corresponding settings page
+        var urlString: String {
+            switch self {
+                case .appSettings: return UIApplication.openSettingsURLString
+                case .notificationSettings:
+                            if #available(iOS 16.0, *) {
+                                return UIApplication.openNotificationSettingsURLString
+                            } else {
+                                return UIApplication.openSettingsURLString
+                            }
+                case .microfonSettings: return "App-Prefs:Privacy&path=MICROPHONE"
+                case .cameraSettings: return "App-Prefs:Privacy&path=CAMERA"
+                case .locationSettings: return "App-Prefs:Privacy&path=LOCATION"
+                case .photosSettings: return "App-Prefs:Privacy&path=PHOTOS"
+                case .siriSettings: return "App-Prefs:SIRI"
+                case .wifiSettings: return "App-Prefs:WIFI"
+                case .bluetoothSettings: return "App-Prefs:Bluetooth"
+                case .cellularSettings: return "App-Prefs:MOBILE_DATA_SETTINGS_ID"
+                case .batterySettings: return "App-Prefs:BATTERY_USAGE"
+                case .privacySettings: return "App-Prefs:Privacy"
+            }
+        }
+    }
+    
+    /// Opens the specified iOS system settings page
+    /// - Parameters:
+    ///   - type: The type of settings to open
+    ///   - completion: Callback closure that returns a boolean indicating success or failure
+    func openSettings(_ type: SettingsType, completion: @escaping (Bool) -> Void) {
+        guard let url = URL(string: type.urlString) else {
+            print("Invalid settings URL")
+            completion(false)
+            return
+        }
+        
+        UIApplication.shared.open(url) { success in
+            if success {
+                print("Successfully opened settings: \(type)")
+            } else {
+                print("Failed to open settings: \(type)")
+            }
+            completion(success)
+        }
+    }
+}


### PR DESCRIPTION
## 📋 PR Description

This PR introduces the `SettingsHelper` class, which provides a centralized way to open various app settings using the `openSettings(_:)` method. The helper supports navigating to specific settings pages such as Notifications, Camera, Location, and more.  

Additionally, `App-Prefs` URL schemes are used to directly open system settings, enabling deeper navigation beyond the standard `UIApplication.openSettingsURLString`. This approach ensures compatibility with older iOS versions, particularly for notification settings, by providing a fallback mechanism.  

This enhancement simplifies the process of directing users to the relevant system settings from within the application.  

---

## ✅ Checklist

- [x] Code follows the project standards and guidelines.
- [ ] Relevant unit tests are written and all tests are passing.
- [ ] Test coverage is adequate for the changes.
- [ ] Any unnecessary files or debug statements have been removed.
- [x] Documentation is updated where necessary.
- [ ] The PR has been reviewed by at least one team member before merging.

---

## 🛠 Steps to Test

1. **Validate URL Generation**  
   - Ensure that each `SettingsType` case generates the correct URL string.  
   - Print `SettingsType.urlString` and compare it with expected values.  

2. **Test Opening Settings** *(on a real device)*  
   - Call `openSettings(_ type: SettingsType, completion:)` for various settings.  
   - Confirm redirection to the correct settings page.  

3. **Handle Edge Cases**  
   - Try opening settings when the app is in different states (foreground, background).  
   - Verify behavior on different iOS versions, especially `notificationSettings` handling in iOS 16+.  

4. **Run Unit Tests**  
   - If applicable, add unit tests for `urlString` validation.  
   - Ensure all tests pass before merging.  

---

## 🔗 Related Links

- Documentation:
- https://www.macstories.net/ios/a-comprehensive-guide-to-all-120-settings-urls-supported-by-ios-and-ipados-13-1/
- https://stackoverflow.com/questions/5655674/opening-the-settings-app-from-another-app
- https://stackoverflow.com/questions/8246070/ios-launching-settings-restrictions-url-scheme?rq=1
- https://developer.apple.com/documentation/uikit/uiapplication/opennotificationsettingsurlstring
- https://developer.apple.com/documentation/uikit/uiapplication/opensettingsurlstring#Discussion
- https://developer.apple.com/documentation/uikit/uiapplication/opendefaultapplicationssettingsurlstring

---

### 📷 Screenshots (Optional)

| Settings | App Settings | Notifications |
|---------|---------|--------------------|
| ![Screenshot 2025-02-07 at 14 21 06](https://github.com/user-attachments/assets/6118993f-16e5-4e2c-8c8f-8c0375e332ca) | ![Screenshot 2025-02-07 at 12 15 39](https://github.com/user-attachments/assets/8d054574-6892-4673-a991-5d58e40bad58) | ![Screenshot 2025-02-07 at 12 15 59](https://github.com/user-attachments/assets/e2f9927c-a600-4be4-91db-c06c1e629258) |

| Microphone | Camera | Privacy & Security |
|--------|---------|-------------|
| ![Screenshot 2025-02-07 at 12 16 09](https://github.com/user-attachments/assets/7c916659-a671-467b-9b82-eaa1f6ed8403) | ![Screenshot 2025-02-07 at 12 16 15](https://github.com/user-attachments/assets/e996fe81-a11a-4fbe-876b-fe8f413354e2) | ![Screenshot 2025-02-07 at 12 16 36](https://github.com/user-attachments/assets/544610de-b965-4b1a-a6ba-80b4c810ea8c)|

| Battery | Location | Siri |
|--------|---------|-------------|
|![Screenshot 2025-02-07 at 12 16 42](https://github.com/user-attachments/assets/e0f81b2f-4c52-4d06-b54d-1ca5741070b8) | ![Screenshot 2025-02-07 at 12 18 31](https://github.com/user-attachments/assets/db7f1233-5e27-4e06-a918-90f55280b8b6) |![Screenshot 2025-02-07 at 12 24 06](https://github.com/user-attachments/assets/879cfb3b-6c50-4d6f-949c-04362ff587a0)|
